### PR TITLE
Just rebuild to see if anything stalls

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ce78d6ef747b5330da01751f2f6cbfc64f8768086fa56a88cd559b53134d87ae
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
some runs stall upon exit from pytest in
https://github.com/conda-forge/pyout-feedstock/pull/7

want to see if we see that here without adding 3.9/rerendering (if feasible)
